### PR TITLE
Add Harmony patch to remove m_TargetAssemblyTypeName

### DIFF
--- a/AssetBundleLoadingTools/AssetBundleLoadingTools.csproj
+++ b/AssetBundleLoadingTools/AssetBundleLoadingTools.csproj
@@ -44,6 +44,10 @@
     <DisableZipRelease>True</DisableZipRelease>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="0Harmony">
+      <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -79,6 +83,7 @@
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
@@ -105,6 +110,7 @@
     <Compile Include="Config\PluginConfig.cs" />
     <Compile Include="Core\Sanitization.cs" />
     <Compile Include="Models\BundleData.cs" />
+    <Compile Include="Patches\PersistentCall.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utilities\AssetBundleHashing.cs" />

--- a/AssetBundleLoadingTools/Patches/PersistentCall.cs
+++ b/AssetBundleLoadingTools/Patches/PersistentCall.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Reflection;
+using HarmonyLib;
+
+namespace AssetBundleLoadingTools.Patches
+{
+    /// <summary>
+    /// This patch removes any serialized m_TargetAssemblyTypeName since that field can be used for bad things, potentially including arbitrary code execution.
+    /// See https://blog.includesecurity.com/2021/06/hacking-unity-games-malicious-unity-game-objects/ for details.
+    /// </summary>
+    [HarmonyPatch]
+    internal class PersistentCall_OnAfterDeserialize
+    {
+        private static readonly Type PersistentCallType = Type.GetType("UnityEngine.Events.PersistentCall, UnityEngine.CoreModule", true);
+        private static readonly MethodInfo OnAfterDeserializeMethod = PersistentCallType.GetMethod("OnAfterDeserialize", BindingFlags.Public | BindingFlags.Instance);
+        private static readonly FieldInfo TargetAssemblyTypeName = PersistentCallType.GetField("m_TargetAssemblyTypeName", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        [HarmonyPriority(Priority.Last)]
+        public static void Postfix(object __instance)
+        {
+            TargetAssemblyTypeName.SetValue(__instance, null);
+        }
+
+        public static MethodBase TargetMethod() => OnAfterDeserializeMethod;
+    }
+}

--- a/AssetBundleLoadingTools/Plugin.cs
+++ b/AssetBundleLoadingTools/Plugin.cs
@@ -1,9 +1,8 @@
 ﻿using AssetBundleLoadingTools.Config;
 using AssetBundleLoadingTools.Core;
+using HarmonyLib;
 using IPA;
-using IPA.Config;
 using IPA.Config.Stores;
-using IPA.Utilities;
 using IPALogger = IPA.Logging.Logger;
 
 namespace AssetBundleLoadingTools
@@ -14,6 +13,8 @@ namespace AssetBundleLoadingTools
     [Plugin(RuntimeOptions.SingleStartInit)]
     internal class Plugin
     {
+        private static readonly Harmony harmony = new("com.legoandmars.assetbundleloadingtools");
+
         internal static Plugin Instance { get; private set; }
         /// <summary>
         /// Use to send log messages through BSIPA.
@@ -35,14 +36,13 @@ namespace AssetBundleLoadingTools
         [OnStart]
         public void OnApplicationStart()
         {
-
+            harmony.PatchAll();
         }
 
         [OnExit]
         public void OnApplicationQuit()
         {
-
+            harmony.UnpatchSelf();
         }
-
     }
 }


### PR DESCRIPTION
Removes unnecessary hashing/caching for objects that aren't having shaders replaced

**NOTE:** Still important any mod loading AssetBundles depends on AssetBundleLoadingTools